### PR TITLE
[PERS-27] Ensure thread safety by removing atom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.2 - 2021-12-14
+- Make FSM compilation thread-safe by removing use of internal atoms.
+
 ## 0.7.1 - 2021-12-14
 - Expose `get-subregistration-id` function in `utils.statement` namespace.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.2 - 2021-12-14
 - Make FSM compilation thread-safe by removing use of internal atoms.
+- Update non-arg `s/cat` specs to `s/tuple` specs.
 
 ## 0.7.1 - 2021-12-14
 - Expose `get-subregistration-id` function in `utils.statement` namespace.

--- a/src/main/com/yetanalytics/persephone/pattern/fsm.cljc
+++ b/src/main/com/yetanalytics/persephone/pattern/fsm.cljc
@@ -289,7 +289,7 @@
                              nfa-coll)
          old-starts  (set (mapv :start nfa-coll))
          old-accepts (mapv #(-> % :accepts first) nfa-coll)
-         max-state   (apply max old-states)
+         max-state   (dec (count old-states)) ; optimization b/c alphatization
          new-start   (+ max-state 1)
          new-accept  (+ max-state 2)
          new-states  (cset/union old-states #{new-start new-accept})


### PR DESCRIPTION
Currently pattern compilation is not thread-safe due to the use of atoms to create alphatized states. This will be changed, e.g. to allow for running parallel tasks that use Persephone pattern compilation, and in general to avoid nasty surprises for devs.