### PR TITLE
Update specs from s/cat to s/tuple

### DIFF
--- a/src/main/com/yetanalytics/persephone.cljc
+++ b/src/main/com/yetanalytics/persephone.cljc
@@ -357,10 +357,9 @@
 ;; Registration Key Construction
 
 (def registration-key-spec
-  (s/or :no-subregistration (s/or :registration ::xs/uuid
-                                  :no-registration #{:no-registration})
-        :subregistration (s/cat :registration ::xs/uuid
-                                :subregistration ::xs/uuid)))
+  (s/or :no-subregistration ::stmt/registration
+        :subregistration (s/tuple ::stmt/registration-id
+                                  ::stmt/subregistration)))
 
 (defn- construct-registration-key
   [profile-id registration ?subreg-ext]
@@ -378,12 +377,10 @@
                           p/state-info-spec)))
 
 (s/def ::accepts
-  (s/every (s/cat :registration-key registration-key-spec
-                  :pattern-id ::pan-pattern/id)))
+  (s/every (s/tuple registration-key-spec ::pan-pattern/id)))
 
 (s/def ::rejects
-  (s/every (s/cat :registration-key registration-key-spec
-                  :pattern-id ::pan-pattern/id)))
+  (s/every (s/tuple registration-key-spec ::pan-pattern/id)))
 
 (def state-info-map-spec
   (s/or :start (s/nilable #{{}})

--- a/src/main/com/yetanalytics/persephone/utils/statement.cljc
+++ b/src/main/com/yetanalytics/persephone/utils/statement.cljc
@@ -49,9 +49,11 @@
 ;; Registration
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(s/def ::registration-id ::xs/uuid)
+
 (s/def ::registration
   (s/or :no-registration #{:no-registration}
-        :registration ::xs/uuid))
+        :registration ::registration-id))
 
 (s/fdef get-statement-registration
   :args (s/cat ::statement ::xs/statement)


### PR DESCRIPTION
`s/cat` has weird semantics, so go with `s/tuple` instead.