### PR TITLE
Patch match failure-related bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.7.3 - 2021-12-15
+- Print match failures (if `:print?` is true) even if it was not the first time that failure was encountered.
+- Add `:nfa-meta` key to the pattern FSMs map (in case meta is lost from `:nfa`).
+
 ## 0.7.2 - 2021-12-14
 - Make FSM compilation thread-safe by removing use of internal atoms.
 - Update non-arg `s/cat` specs to `s/tuple` specs.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Each Pattern is essentially a regular expression on Statement Templates, which c
 with `:dfa` and `:nfa` being two different FSMs:
 - `:dfa` is a (mostly: see below) deterministic, minimized FSM used for efficient matching of Statements against a Pattern.
 - `:nfa` is a non-deterministic NFA with pattern metadata associated with each of its states. This is an optional value; if present, it is used to reconstruct the path from the primary pattern to the template when constructing match failure data.
+- `:nfa-meta` is the metadata for the `:nfa` value; this is only present if `:nfa` is.
 
 (NOTE: Unlike "true" DFAs, `:dfa` allows for some level of non-determinism, since a Statement may match against multiple Templates.)
 

--- a/src/main/com/yetanalytics/persephone.cljc
+++ b/src/main/com/yetanalytics/persephone.cljc
@@ -309,11 +309,13 @@
   and `pattern-id` is the ID of a primary Pattern in that Profile. The
   leaf values include the following: 
      
-     `:id`  The pattern ID.
-     `:dfa` The DFA used for general pattern matching.
-     `:nfa` The NFA with pattern metadata used for reconstructing the
-            pattern path. This is an optional property that is only
-            produced when `:compile-nfa?` is `true`.
+     `:id`       The pattern ID.
+     `:dfa`      The DFA used for general pattern matching.
+     `:nfa`      The NFA with pattern metadata used for reconstructing the
+                 pattern path. This is an optional property that is only
+                 produced when `:compile-nfa?` is `true`.
+     `:nfa-meta` The NFA metadata; assoc-ed here in case meta is lost
+                 from the `:nfa` value. Only present if `:nfa` is.
    The following are optional arguments:
 
      :statement-ref-fns  takes the key-value pairs described in
@@ -406,7 +408,13 @@
   "Match `statement` against the pattern DFA, and upon failure (i.e.
    `fsm/read-next` returns `#{}`), append printable failure metadata
    to the return value."
-  [{pat-id :id pat-dfa :dfa ?pat-nfa :nfa} state-info statement print?]
+  [{pat-id    :id
+    pat-dfa   :dfa
+    ?pat-nfa  :nfa
+    ?nfa-meta :nfa-meta}
+   state-info
+   statement
+   print?]
   (let [start-opts  {:record-visits? (some? ?pat-nfa)}
         new-st-info (fsm/read-next pat-dfa start-opts state-info statement)]
     (if (empty? new-st-info)
@@ -416,12 +424,17 @@
             (println (perr-printer/error-msg-str (:failure old-meta))))
           (with-meta new-st-info old-meta))
         (let [?fail-trc (when ?pat-nfa
-                          (let [build-trace
+                          (let [read-temp-ids
+                                (if ?nfa-meta
+                                  (partial p/read-visited-templates
+                                           ?pat-nfa
+                                           ?nfa-meta)
+                                  (partial p/read-visited-templates
+                                           ?pat-nfa))
+                                build-trace
                                 (fn [temp-ids]
                                   {:templates temp-ids
-                                   :patterns  (p/read-visited-templates
-                                               ?pat-nfa
-                                               temp-ids)})]
+                                   :patterns  (read-temp-ids temp-ids)})]
                             (->> state-info
                                  (map :visited)
                                  (map build-trace))))


### PR DESCRIPTION
- Print match failures (if `:print?` is true) even if it was not the first time that failure was encountered.
- Add `:nfa-meta` key to the pattern FSMs map (in case meta is lost from `:nfa`).