### PR TITLE
Instrument and fix specs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,6 +33,7 @@
   {:extra-paths ["src/test" "src/gen" "test-resources"]
    :extra-deps  {org.clojure/test.check  {:mvn/version "1.1.0"}
                  org.clojure/data.json   {:mvn/version "1.0.0"} ; clj only
+                 orchestra/orchestra     {:mvn/version "2021.01.01-1"}
                  olical/cljs-test-runner {:mvn/version "3.8.0"
                                           :exclusions  [org.clojure/clojurescript
                                                         org.clojure/data.json]}

--- a/src/main/com/yetanalytics/persephone.cljc
+++ b/src/main/com/yetanalytics/persephone.cljc
@@ -27,9 +27,15 @@
 (s/def ::selected-templates (s/every ::pan-template/id))
 (s/def ::selected-patterns (s/every ::pan-pattern/id))
 
-(s/def ::error #{::stmt/missing-profile-reference
-                 ::stmt/invalid-subreg-no-registration
-                 ::stmt/invalid-subreg-nonconformant})
+(s/def ::type #{::stmt/missing-profile-reference
+                ::stmt/invalid-subreg-no-registration
+                ::stmt/invalid-subreg-nonconformant})
+
+(s/def ::error
+  (s/keys :req-un [::type ::xs/statement]))
+
+(def stmt-error-spec
+  (s/keys :req-un [::error]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Statement Validation Functions
@@ -469,9 +475,6 @@
                                    ::rejects
                                    ::states-map])))
 
-(def match-stmt-error-spec
-  (s/keys :req-un [::error ::xs/statement]))
-
 (defn- match-statement-vs-pattern
   "Match `statement` against the pattern DFA, and upon failure (i.e.
    `fsm/read-next` returns `#{}`), append printable failure metadata
@@ -520,10 +523,10 @@
 (s/fdef match-statement
   :args (s/cat :compiled-profiles compiled-profiles-spec
                :state-info-map    state-info-map-spec
-               :statement         (s/or :error match-stmt-error-spec
+               :statement         (s/or :error stmt-error-spec
                                         :ok ::xs/statement)
                :kwargs            (s/keys* :opt-un [::print?]))
-  :ret (s/or :error match-stmt-error-spec
+  :ret (s/or :error stmt-error-spec
              :ok state-info-map-spec))
 
 (defn match-statement
@@ -631,9 +634,9 @@
 (s/fdef match-statement-batch
   :args (s/cat :compiled-profiles compiled-profiles-spec
                :state-info-map    state-info-map-spec
-               :statement-batch   (s/coll-of (s/or :error match-stmt-error-spec
+               :statement-batch   (s/coll-of (s/or :error stmt-error-spec
                                                    :ok ::xs/statement)))
-  :ret (s/or :error match-stmt-error-spec
+  :ret (s/or :error stmt-error-spec
              :ok state-info-map-spec))
 
 (defn match-statement-batch

--- a/src/main/com/yetanalytics/persephone.cljc
+++ b/src/main/com/yetanalytics/persephone.cljc
@@ -522,9 +522,9 @@
 
 (s/fdef match-statement
   :args (s/cat :compiled-profiles compiled-profiles-spec
-               :state-info-map    state-info-map-spec
-               :statement         (s/or :error stmt-error-spec
-                                        :ok ::xs/statement)
+               :state-info-map    (s/or :error stmt-error-spec
+                                        :ok state-info-map-spec)
+               :statement         ::xs/statement
                :kwargs            (s/keys* :opt-un [::print?]))
   :ret (s/or :error stmt-error-spec
              :ok state-info-map-spec))
@@ -633,9 +633,9 @@
 
 (s/fdef match-statement-batch
   :args (s/cat :compiled-profiles compiled-profiles-spec
-               :state-info-map    state-info-map-spec
-               :statement-batch   (s/coll-of (s/or :error stmt-error-spec
-                                                   :ok ::xs/statement)))
+               :state-info-map    (s/or :error stmt-error-spec
+                                        :ok state-info-map-spec)
+               :statement-batch   (s/coll-of ::xs/statement))
   :ret (s/or :error stmt-error-spec
              :ok state-info-map-spec))
 

--- a/src/main/com/yetanalytics/persephone/pattern/fsm.cljc
+++ b/src/main/com/yetanalytics/persephone/pattern/fsm.cljc
@@ -391,7 +391,8 @@
 ;; -> q --> s ==> s --> f
 
 (s/fdef plus-nfa
-  :args (s/cat :nfa fs/thompsons-nfa-spec)
+  :args (s/cat :nfa fs/thompsons-nfa-spec
+               :meta? (s/? boolean?))
   :ret fs/thompsons-nfa-spec)
 
 (defn plus-nfa
@@ -687,7 +688,7 @@
 (s/def ::start-opts (s/keys :opt-un [::record-visits?]))
 
 (s/fdef read-next
-  :args (s/cat :dfa fs/dfa-spec
+  :args (s/cat :fsm (s/or :nfa fs/nfa-spec :dfa fs/dfa-spec)
                :start-opts (s/? ::start-opts)
                :state-info (s/nilable fs/state-info-spec)
                :input any?)

--- a/src/main/com/yetanalytics/persephone/pattern/fsm_spec.cljc
+++ b/src/main/com/yetanalytics/persephone/pattern/fsm_spec.cljc
@@ -33,7 +33,7 @@
   (let [trans-srcs (reduce-kv (fn [acc src _] (conj acc src))
                               #{}
                               transitions)]
-    (= states trans-srcs)))
+    (cset/subset? trans-srcs states)))
 
 (defn- valid-transition-dest-states?
   [collect-dest-fn {:keys [states transitions] :as _fsm}]

--- a/src/main/com/yetanalytics/persephone/template.cljc
+++ b/src/main/com/yetanalytics/persephone/template.cljc
@@ -219,22 +219,22 @@
         (cond
           (not sref)
           [{:pred :statement-ref?
-            :vals statement
+            :vals [statement]
             :sref {:location     stmt-ref-path
                    :sref-failure :sref-not-found}}]
           (not sref-type?)
           [{:pred :statement-ref?
-            :vals sref
+            :vals [sref]
             :sref {:location     stmt-ref-path
                    :sref-failure :sref-object-type-invalid}}]
           (not sref-id)
           [{:pred :statement-ref?
-            :vals sref
+            :vals [sref]
             :sref {:location     stmt-ref-path
                    :sref-failure :sref-id-missing}}]
           (not sref-stmt)
           [{:pred :statement-ref?
-            :vals sref-id
+            :vals [sref-id]
             :sref {:location     stmt-ref-path
                    :sref-failure :sref-stmt-not-found}}]
           ;; TODO: Add additional errors for referencing future statements?

--- a/src/main/com/yetanalytics/persephone/template.cljc
+++ b/src/main/com/yetanalytics/persephone/template.cljc
@@ -1,7 +1,6 @@
 (ns com.yetanalytics.persephone.template
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as string]
-            [xapi-schema.spec :as xs]
             [com.yetanalytics.pan.axioms :as ax]
             [com.yetanalytics.pan.objects.template :as pan-temp]
             [com.yetanalytics.pan.objects.templates.rules :as pan-rules]
@@ -276,10 +275,15 @@
                                             "$.context.statement"
                                             ?stmt-ref-opts)))))
 
-(def validator-spec
-  (s/fspec
-   :args (s/cat :statement ::xs/statement)
-   :ret (s/nilable (s/coll-of validation-result-spec))))
+(def validator-spec fn?)
+
+;; The fspec is the detailed spec, but is commented out or else
+;; instrumented fns slow to a crawl.
+
+;; (def validator-spec
+;;   (s/fspec
+;;    :args (s/cat :statement ::xs/statement)
+;;    :ret (s/nilable (s/coll-of validation-result-spec))))
 
 (s/fdef create-template-validator
   :args (s/cat :template ::pan-temp/template
@@ -366,9 +370,15 @@
                                             ?stmt-ref-opts)))))
 
 (def predicate-spec
-  (s/fspec
-   :args (s/cat :statement ::xs/statement)
-   :ret boolean?))
+  fn?)
+
+;; The fspec is the detailed spec, but is commented out or else
+;; instrumented fns slow to a crawl.
+
+;; (def predicate-spec
+;;   (s/fspec
+;;    :args (s/cat :statement ::xs/statement)
+;;    :ret boolean?))
 
 ;; TODO: Seems kind of dumb to have a nilable opt arg?
 (s/fdef create-template-predicate

--- a/src/main/com/yetanalytics/persephone/template.cljc
+++ b/src/main/com/yetanalytics/persephone/template.cljc
@@ -14,7 +14,8 @@
 ;; Specs 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(s/def ::stmt :statement/id)
+;; Statement IDs are technically optional
+(s/def ::stmt (s/nilable :statement/id))
 (s/def ::temp ::pan-temp/id)
 
 (s/def ::vals (s/coll-of any?))
@@ -26,8 +27,9 @@
     :any-matchable?
     :some-any-values?
     :only-all-values?
-    :no-unmatch-vals?
-    :no-none-values?})
+    :no-none-values?
+    :every-val-present?
+    :no-unmatch-vals?})
 
 (s/def ::location ::pan-rules/location)
 
@@ -277,11 +279,11 @@
 (def validator-spec
   (s/fspec
    :args (s/cat :statement ::xs/statement)
-   :ret validation-result-spec))
+   :ret (s/nilable (s/coll-of validation-result-spec))))
 
 (s/fdef create-template-validator
   :args (s/cat :template ::pan-temp/template
-               :statement-ref-fns (s/? ::sref/statement-ref-fns))
+               :statement-ref-fns (s/? (s/nilable ::sref/statement-ref-fns)))
   :ret validator-spec)
 
 (defn create-template-validator
@@ -368,9 +370,10 @@
    :args (s/cat :statement ::xs/statement)
    :ret boolean?))
 
+;; TODO: Seems kind of dumb to have a nilable opt arg?
 (s/fdef create-template-predicate
   :args (s/cat :template ::pan-temp/template
-               :statement-ref-fns (s/? ::sref/statement-ref-fns))
+               :statement-ref-fns (s/? (s/nilable ::sref/statement-ref-fns)))
   :ret predicate-spec)
 
 (defn create-template-predicate

--- a/src/main/com/yetanalytics/persephone/template/errors.cljc
+++ b/src/main/com/yetanalytics/persephone/template/errors.cljc
@@ -118,7 +118,7 @@
     ;; Statement Ref Templates
     sref
     (let [{fail :sref-failure sref :location} sref]
-      (sref-error-str fail sref vals))
+      (sref-error-str fail sref (first vals)))
     ;; Determining Properties
     prop
     (let [{prop :det-prop mvals :match-vals} prop]

--- a/src/main/com/yetanalytics/persephone/template/statement_ref.cljc
+++ b/src/main/com/yetanalytics/persephone/template/statement_ref.cljc
@@ -11,12 +11,13 @@
 ;; Specs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; ::pan-template/id doesn't have a generator
 (s/def ::get-template-fn
-  (s/fspec :args (s/cat :template-id ::pan-template/id)
-           :ret ::pan-template/template))
+  (s/fspec :args (s/cat :template-id ::xs/iri)
+           :ret (s/nilable ::pan-template/template)))
 (s/def ::get-statement-fn
   (s/fspec :args (s/cat :statement-id :statement/id)
-           :ret ::xs/statement))
+           :ret (s/nilable ::xs/statement)))
 (s/def ::statement-ref-fns
   (s/keys :req-un [::get-template-fn
                    ::get-statement-fn]))

--- a/src/main/com/yetanalytics/persephone/template/statement_ref.cljc
+++ b/src/main/com/yetanalytics/persephone/template/statement_ref.cljc
@@ -15,9 +15,11 @@
 (s/def ::get-template-fn
   (s/fspec :args (s/cat :template-id ::xs/iri)
            :ret (s/nilable ::pan-template/template)))
+
 (s/def ::get-statement-fn
   (s/fspec :args (s/cat :statement-id :statement/id)
            :ret (s/nilable ::xs/statement)))
+
 (s/def ::statement-ref-fns
   (s/keys :req-un [::get-template-fn
                    ::get-statement-fn]))

--- a/src/main/com/yetanalytics/persephone/utils/statement.cljc
+++ b/src/main/com/yetanalytics/persephone/utils/statement.cljc
@@ -31,8 +31,8 @@
 (s/fdef get-statement-profile-ids
   :args (s/cat :statement ::xs/statement
                :profile-id-set (s/every ::pan-prof/id :kind set?))
-  :ret (s/or :error #{::missing-profile-reference}
-             :ok (s/every ::pan-prof/id :kind set?)))
+  :ret (s/or :ok (s/every ::pan-prof/id :kind set?)
+             :error #{::missing-profile-reference}))
 
 (defn get-statement-profile-ids
   "Get the category context activity IDs that are also profile IDs, or
@@ -81,7 +81,9 @@
 (s/fdef get-statement-subregistration
   :args (s/cat :statement ::xs/statement
                :registration ::registration)
-  :ret subregistration-spec)
+  :ret (s/or :ok (s/nilable subregistration-spec)
+             :error #{::invalid-subreg-no-registration
+                      ::invalid-subreg-nonconformant}))
 
 (defn get-statement-subregistration
   "Given `statement` and `registration`, return the subregistration

--- a/src/test/com/yetanalytics/persephone_test.cljc
+++ b/src/test/com/yetanalytics/persephone_test.cljc
@@ -846,13 +846,16 @@ Pattern path:
                 :error
                 :type))))
   (testing "error input returns the same"
-    ;; THESE TESTS FAIL WHEN INSTRUMENTATION IS ON
     (is (= {:error {:type      ::stmt/missing-profile-reference
-                    :statement nil}}
-           (match-cmi {:error ::stmt/missing-profile-reference} nil)))
+                    :statement {}}}
+           (match-cmi {:error {:type ::stmt/missing-profile-reference
+                               :statement {}}}
+                      {})))
     (is (= {:error {:type      ::stmt/missing-profile-reference
-                    :statement nil}}
-           (match-cmi-2 {:error ::stmt/missing-profile-reference} nil)))))
+                    :statement {}}}
+           (match-cmi-2 {:error {:type      ::stmt/missing-profile-reference
+                                 :statement {}}}
+                        {})))))
 
 ;; Batch Matching Tests
 

--- a/src/test/com/yetanalytics/persephone_test.cljc
+++ b/src/test/com/yetanalytics/persephone_test.cljc
@@ -165,9 +165,6 @@
 (def cmi-profile (-> (slurp "test-resources/sample_profiles/cmi5.json")
                      (test-u/json->edn :keywordize? true)))
 
-(def cmi-templates (:templates cmi-profile))
-
-(def cmi-profile-id "https://w3id.org/xapi/cmi5")
 (def cmi-version-id "https://w3id.org/xapi/cmi5/v1.0")
 (def cmi-pattern-id "https://w3id.org/xapi/cmi5#toplevel")
 
@@ -294,7 +291,7 @@
     (is (p/validate-statement cmi-tmpl-9 satisfied-stmt))))
 
 (deftest cmi-statement-test-2
-  (testing "calling validate-statement-vs-template with different modes"
+  (testing "calling validate-statement with different modes"
     (testing "on valid statements"
       (is (= ex-statement
              (p/validate-statement
@@ -766,7 +763,7 @@ Pattern path:
                     (match-cmi-2 abandoned-stmt)
                     (match-cmi-2 satisfied-stmt-2)
                     (get-in [:states-map registration-2 cmi-pattern-id])))))
-  (testing "the match-statement-vs-profile function w/ sub-registrations."
+  (testing "the match-statement function w/ sub-registrations."
     (is (= 4 (-> {}
                  (match-cmi-2 satisfied-stmt)
                  (match-cmi-2 satisfied-stmt-2)
@@ -849,9 +846,12 @@ Pattern path:
                 :error
                 :type))))
   (testing "error input returns the same"
-    (is (= {:error ::stmt/missing-profile-reference}
+    ;; THESE TESTS FAIL WHEN INSTRUMENTATION IS ON
+    (is (= {:error {:type      ::stmt/missing-profile-reference
+                    :statement nil}}
            (match-cmi {:error ::stmt/missing-profile-reference} nil)))
-    (is (= {:error ::stmt/missing-profile-reference}
+    (is (= {:error {:type      ::stmt/missing-profile-reference
+                    :statement nil}}
            (match-cmi-2 {:error ::stmt/missing-profile-reference} nil)))))
 
 ;; Batch Matching Tests

--- a/src/test/com/yetanalytics/persephone_test.cljc
+++ b/src/test/com/yetanalytics/persephone_test.cljc
@@ -423,20 +423,19 @@
              (p/validate-statement cmi-validator
                                    ex-statement
                                    :fn-type :templates))))
-    (testing "- invalid Statement (just an empty map)"
-      ;; THESE TESTS WILL FAIL IF INSTRUMENTATION IS ON
+    (testing "- invalid Statement"
       (is (not (p/validate-statement cmi-validator
-                                     {}
+                                     (dissoc ex-statement "id" "result")
                                      :fn-type :predicate)))
       (is (nil? (p/validate-statement cmi-validator
-                                      {}
+                                      (dissoc ex-statement "id" "result")
                                       :fn-type :filter)))
       (is (= [] (p/validate-statement cmi-validator
-                                      {}
+                                      (dissoc ex-statement "id" "result")
                                       :fn-type :templates)))
       (is (= 10 (count
                  (p/validate-statement cmi-validator
-                                       {}
+                                       (dissoc ex-statement "id" "result")
                                        :fn-type :errors))))
       (is (= {:pred :any-matchable?
               :vals [nil]
@@ -445,15 +444,15 @@
               :temp "https://w3id.org/xapi/cmi5#generalrestrictions"
               :stmt nil}
              (-> (p/validate-statement cmi-validator
-                                       {}
+                                       (dissoc ex-statement "id" "result")
                                        :fn-type :errors)
                  (get "https://w3id.org/xapi/cmi5#generalrestrictions")
                  first)))
       (is (= (p/validate-statement cmi-validator
-                                   {}
+                                   (dissoc ex-statement "id" "result")
                                    :fn-type :errors)
              (try (p/validate-statement cmi-validator
-                                        {}
+                                        (dissoc ex-statement "id" "result")
                                         :fn-type :errors)
                   (catch #?(:clj Exception :cljs js/Error) e
                     (-> e ex-data :errors))))))))
@@ -846,17 +845,16 @@ Pattern path:
                 :error
                 :type))))
   (testing "error input returns the same"
-    ;; THESE TESTS WILL FAIL WHEN INSTRUMENTATION IS TURNED ON
     (is (= {:error {:type      ::stmt/missing-profile-reference
-                    :statement {}}}
+                    :statement ex-statement}}
            (match-cmi {:error {:type ::stmt/missing-profile-reference
-                               :statement {}}}
-                      {})))
+                               :statement ex-statement}}
+                      ex-statement)))
     (is (= {:error {:type      ::stmt/missing-profile-reference
-                    :statement {}}}
+                    :statement ex-statement}}
            (match-cmi-2 {:error {:type      ::stmt/missing-profile-reference
-                                 :statement {}}}
-                        {})))))
+                                 :statement ex-statement}}
+                        ex-statement)))))
 
 ;; Batch Matching Tests
 

--- a/src/test/com/yetanalytics/persephone_test.cljc
+++ b/src/test/com/yetanalytics/persephone_test.cljc
@@ -846,6 +846,7 @@ Pattern path:
                 :error
                 :type))))
   (testing "error input returns the same"
+    ;; THESE TESTS WILL FAIL WHEN INSTRUMENTATION IS TURNED ON
     (is (= {:error {:type      ::stmt/missing-profile-reference
                     :statement {}}}
            (match-cmi {:error {:type ::stmt/missing-profile-reference

--- a/src/test/com/yetanalytics/persephone_test.cljc
+++ b/src/test/com/yetanalytics/persephone_test.cljc
@@ -380,7 +380,8 @@
                       ex-statement
                       :fn-type :printer)))))
     (testing "invalid :fn-type"
-      ;; THIS TEST WILL FAIL IF INSTRUMENTATION IS ON
+      ;; This test will throw different exceptions depending on if
+      ;; instrumentation is turned on or not, but should still pass.
       (is (try (ex-statement
                 (p/validate-statement
                  cmi-tmpl-0

--- a/src/test/com/yetanalytics/persephone_test/test_utils.cljc
+++ b/src/test/com/yetanalytics/persephone_test/test_utils.cljc
@@ -50,3 +50,10 @@
   (instrument-persephone)
   (f)
   (unstrument-persephone))
+
+(comment
+  ;; Keep instrumentation off by default since
+  ;; 1. some tests will fail (e.g. because they test invalid inputs on purpose)
+  ;; 2. it is insanely slow
+  (instrument-persephone)
+  (unstrument-persephone))

--- a/src/test/com/yetanalytics/persephone_test/test_utils.cljc
+++ b/src/test/com/yetanalytics/persephone_test/test_utils.cljc
@@ -56,8 +56,7 @@
            set)))
 
 (comment
-  ;; Keep instrumentation off by default since
-  ;; 1. some tests will fail (e.g. because they test invalid inputs on purpose)
-  ;; 2. it is insanely slow
+  ;; TODO: Add the instrumentation as a fixture
+  ;; (including in ClojureScript, somehow)
   (otest/instrument #?(:clj (persephone-syms) :cljs (persephone-syms-macro)))
   (otest/unstrument #?(:clj (persephone-syms) :cljs (persephone-syms-macro))))

--- a/src/test/com/yetanalytics/persephone_test/test_utils.cljc
+++ b/src/test/com/yetanalytics/persephone_test/test_utils.cljc
@@ -1,8 +1,8 @@
 (ns com.yetanalytics.persephone-test.test-utils
-  (:require [clojure.spec.test.alpha :as stest]
-            [orchestra.spec.test     :as otest]
-            [com.yetanalytics.pan.utils.json :refer [convert-json]]
-            #?(:clj [clojure.data.json :as json])))
+  (:require [com.yetanalytics.pan.utils.json :refer [convert-json]]
+            #?@(:clj [[clojure.data.json :as json]
+                      [clojure.spec.test.alpha :as stest]
+                      [orchestra.spec.test     :as otest]])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; JSON Parsing
@@ -21,39 +21,45 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Instrumentation
+;; CLJ-only, since for some reason the dep throws an ExceptionInfo in cljs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- persephone-sym-filter
-  [sym]
-  (->> sym
-       namespace
-       (re-matches #"com\.yetanalytics\.persephone.*")))
+#?(:clj
+   (defn- persephone-sym-filter
+     [sym]
+     (->> sym
+          namespace
+          (re-matches #"com\.yetanalytics\.persephone.*"))))
 
-(defn- persephone-syms
-  []
-  (->> (stest/instrumentable-syms)
-       (filter persephone-sym-filter)
-       set))
+#?(:clj
+   (defn- persephone-syms
+     []
+     (->> (stest/instrumentable-syms)
+          (filter persephone-sym-filter)
+          set)))
 
-(defn instrument-persephone
-  "Instrument all instrumentable functions defined in persephone."
-  []
-  (otest/instrument (persephone-syms)))
+#?(:clj
+   (defn instrument-persephone
+     "Instrument all instrumentable functions defined in persephone."
+     []
+     (otest/instrument (persephone-syms))))
 
-(defn unstrument-persephone
-  "Instrument all instrumentable functions defined in persephone."
-  []
-  (otest/unstrument (persephone-syms)))
+#?(:clj
+   (defn unstrument-persephone
+     "Instrument all instrumentable functions defined in persephone."
+     []
+     (otest/unstrument (persephone-syms))))
 
-(defn instrumentation-fixture
-  [f]
-  (instrument-persephone)
-  (f)
-  (unstrument-persephone))
+#?(:clj
+   (defn instrumentation-fixture
+     [f]
+     (instrument-persephone)
+     (f)
+     (unstrument-persephone)))
 
 (comment
   ;; Keep instrumentation off by default since
   ;; 1. some tests will fail (e.g. because they test invalid inputs on purpose)
   ;; 2. it is insanely slow
-  (instrument-persephone)
-  (unstrument-persephone))
+  #?(:clj (instrument-persephone))
+  #?(:clj (unstrument-persephone)))


### PR DESCRIPTION
- Update `:vals` field in template error map to _always_ be a vector, even for Statement Ref errors (BREAKING)
- Update `fsm-spec/valid-transition-src-states?` such that source states only have to be a _subset_, not equals to, the total states.
- Add `:meta?` to spec for `fsm/plus-nfa`.
- Correct instrumentation for `read-next` to work with NFAs as well as DFAs.
- Let `statement-ref/get-template-fn` and `statement-ref/get-statement-fn` specs to allow for `nil` returns and fix arg generation.
- Fix subregistration specs in `utils/statement`.
- Add missing `:every-val-present?` entry to `::template/pred` spec.
- Fix `validator-spec`, `create-template-validator` and `create-template-predicate` template specs.
- Fix typo in `::persephone/validator-fn` and `::persephone/predicate-fn` spec names.
- Align specs for `validate-statement-errors` and `validate-statement` (for `:fn-type :errors`).
- Add missing `::persephone/print?` spec for `match-statement`.
- Fix bug in `::persephone/error` spec.