### PR TITLE
Spec updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,11 @@ pom.xml.asc
 .hgignore
 .hg/
 
-# Calva + linting
+# VSCode stuff
 .calva
 .clj-kondo
 .lsp
+.vscode/
 
 # Image output files
 *.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Deprecate `stmt-error` and `util.statement.subreg-iri` in favor of `statement-error` and `subregistration-iri`, respectively (while keeping the values identical).
 - Add `pattern.failure` namespace and specs such as `::failure/failure` and `state-info-meta-spec` for failure info/state info metadata.
 - Add docstrings to API specs.
+- (Test-only) Add spec instrumentation fixture and apply it to API function tests.
 
 ## 0.8.1 - 2022-03-08
 - Implement Clojars deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.8.2 = 2022-06-30
+- Deprecate `stmt-error` and `util.statement.subreg-iri` in favor of `statement-error` and `subregistration-iri`, respectively (while keeping the values identical).
+- Add `pattern.failure` namespace and specs such as `::failure/failure` and `state-info-meta-spec` for failure info/state info metadata.
+- Add docstrings to API specs.
+
 ## 0.8.1 - 2022-03-08
 - Implement Clojars deployment
 - Update dependencies

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Clojure library for validating xAPI Statements against xAPI Profiles.
 
 Add the following to the `:deps` map in your `deps.edn` file:
 ```clojure
-com.yetanalytics/project-persephone {:mvn/version "0.8.1"
+com.yetanalytics/project-persephone {:mvn/version "0.8.2"
                                      :exclusions [org.clojure/clojure
                                                   org.clojure/clojurescript]}
 ```

--- a/src/main/com/yetanalytics/persephone.cljc
+++ b/src/main/com/yetanalytics/persephone.cljc
@@ -35,7 +35,11 @@
 (s/def ::error
   (s/keys :req-un [::type ::xs/statement]))
 
-(def stmt-error-spec
+;; TODO: Delete in next break ver
+(def ^:deprecated stmt-error-spec
+  (s/keys :req-un [::error]))
+
+(def statement-error-spec
   (s/keys :req-un [::error]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -560,11 +564,11 @@
 
 (s/fdef match-statement
   :args (s/cat :compiled-profiles compiled-profiles-spec
-               :state-info-map    (s/or :error stmt-error-spec
+               :state-info-map    (s/or :error statement-error-spec
                                         :ok state-info-map-spec)
                :statement         ::xs/statement
                :kwargs            (s/keys* :opt-un [::print?]))
-  :ret (s/or :error stmt-error-spec
+  :ret (s/or :error statement-error-spec
              :ok state-info-map-spec))
 
 (defn match-statement
@@ -671,10 +675,10 @@
 
 (s/fdef match-statement-batch
   :args (s/cat :compiled-profiles compiled-profiles-spec
-               :state-info-map    (s/or :error stmt-error-spec
+               :state-info-map    (s/or :error statement-error-spec
                                         :ok state-info-map-spec)
                :statement-batch   (s/coll-of ::xs/statement))
-  :ret (s/or :error stmt-error-spec
+  :ret (s/or :error statement-error-spec
              :ok state-info-map-spec))
 
 (defn match-statement-batch

--- a/src/main/com/yetanalytics/persephone.cljc
+++ b/src/main/com/yetanalytics/persephone.cljc
@@ -167,7 +167,7 @@
 ;; ***** Statement Validation *****
 
 (s/def ::all-valid? boolean?)
-(s/def ::short-circuit boolean?)
+(s/def ::short-circuit? boolean?)
 (s/def ::fn-type #{:predicate
                    :filter
                    :errors

--- a/src/main/com/yetanalytics/persephone.cljc
+++ b/src/main/com/yetanalytics/persephone.cljc
@@ -552,10 +552,6 @@
 
 ;; Statement Pattern Matching ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- println-optional
-  [print? x]
-  (when print? (println x)))
-
 (defn- match-statement-vs-pattern
   "Match `statement` against the pattern DFA, and upon failure (i.e.
    `fsm/read-next` returns `#{}`), append printable failure metadata
@@ -569,16 +565,15 @@
   (let [start-opts  {:record-visits? (some? ?pat-nfa)}
         new-st-info (fsm/read-next pat-dfa start-opts state-info statement)]
     (if (empty? new-st-info)
-      (if-some [old-meta (meta state-info)]
+      (if-some [{old-fail-meta :failure :as old-meta} (meta state-info)]
         (do
-          (println-optional print?
-                            (perr-printer/error-msg-str (:failure old-meta)))
+          (when print? (println (perr-printer/error-msg-str old-fail-meta)))
           (with-meta new-st-info old-meta))
         (let [fail-meta (fmeta/construct-failure-info
                          fsms
                          state-info
                          statement)]
-          (println-optional print? (perr-printer/error-msg-str fail-meta)) 
+          (when print? (println (perr-printer/error-msg-str fail-meta))) 
           (with-meta new-st-info {:failure fail-meta})))
       new-st-info)))
 

--- a/src/main/com/yetanalytics/persephone/pattern.cljc
+++ b/src/main/com/yetanalytics/persephone/pattern.cljc
@@ -225,6 +225,7 @@
 ;; Putting it all together
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; TODO: Remove in next break ver
 (s/def ::nfa-meta
   (s/keys :opt-un [:meta/states]))
 

--- a/src/main/com/yetanalytics/persephone/pattern/failure.cljc
+++ b/src/main/com/yetanalytics/persephone/pattern/failure.cljc
@@ -1,0 +1,64 @@
+(ns com.yetanalytics.persephone.pattern.failure
+  "Util namespace to construct the failure map for pattern matching, with
+   included specs."
+  (:require [clojure.spec.alpha :as s]
+            [com.yetanalytics.pan.objects.template  :as pan-template]
+            [com.yetanalytics.pan.objects.pattern   :as pan-pattern]
+            [com.yetanalytics.persephone.pattern    :as p]
+            [com.yetanalytics.persephone.utils.spec :refer [lazy-seq?]]))
+
+;; Specs
+
+(s/def ::statement :statement/id)
+(s/def ::pattern ::pan-pattern/id)
+
+;; The templates that were visited during matching
+(s/def ::templates
+  (s/coll-of ::pan-template/id :kind vector?))
+
+;; The different paths of patterns that were taken during matching
+(s/def ::patterns
+  (s/coll-of (s/coll-of ::pan-pattern/id :kind vector?) :kind lazy-seq?))
+
+;; Trace info - all templates visited + all pattern paths taken
+(s/def ::traces
+  (s/coll-of (s/keys :req-un [::templates ::patterns])
+             :kind lazy-seq?))
+
+;; Basic info (statement + pattern IDs) and optional trace info
+(s/def ::failure
+  (s/keys :req-un [::statement ::pattern]
+          :opt-un [::traces]))
+
+;; Functions
+
+(defn construct-failure-info
+  "Construct the failure map given `fsms`, `state-info`, and `statement`,
+   where the failure map is has `:statement`, `:pattern`, and optional
+   `:traces` keys."
+  [{pat-id    :id
+    ?pat-nfa  :nfa
+    ?nfa-meta :nfa-meta
+    :as       _fsms}
+   state-info
+   {stmt-id "id" :as _statement}]
+  (if ?pat-nfa
+    ;; Use the pattern NFA to build the traces data structure
+    (let [read-template-ids
+          (if ?nfa-meta
+            (partial p/read-visited-templates ?pat-nfa ?nfa-meta)
+            (partial p/read-visited-templates ?pat-nfa))
+          build-trace
+          (fn [temp-ids]
+            {:templates temp-ids
+             :patterns  (read-template-ids temp-ids)})
+          fail-traces
+          (->> state-info
+               (map :visited)
+               (map build-trace))]
+      {:statement stmt-id
+       :pattern   pat-id
+       :traces    fail-traces})
+    ;; No pattern NFA available - just return basic info
+    {:statement stmt-id
+     :pattern   pat-id}))

--- a/src/main/com/yetanalytics/persephone/pattern/fsm_spec.cljc
+++ b/src/main/com/yetanalytics/persephone/pattern/fsm_spec.cljc
@@ -302,5 +302,9 @@
 (s/def :meta/states
   (s/every-kv (s/or :nfa :nfa/state :dfa :int-dfa/state) any?))
 
-(def fsm-metadata-spec
+;; TODO: Remove in next break ver
+(def ^:deprecated fsm-metadata-spec
+  (s/keys :opt-un [:meta/states]))
+
+(s/def ::nfa-meta
   (s/keys :opt-un [:meta/states]))

--- a/src/main/com/yetanalytics/persephone/template.cljc
+++ b/src/main/com/yetanalytics/persephone/template.cljc
@@ -275,7 +275,8 @@
                                             "$.context.statement"
                                             ?stmt-ref-opts)))))
 
-(def validator-spec fn?)
+(def validator-spec
+  fn?)
 
 ;; The fspec is the detailed spec, but is commented out or else
 ;; instrumented fns slow to a crawl.

--- a/src/main/com/yetanalytics/persephone/utils/spec.cljc
+++ b/src/main/com/yetanalytics/persephone/utils/spec.cljc
@@ -20,3 +20,10 @@
   "Same as subreg-ext-spec* but expects string keys."
   (s/and (s/conformer w/keywordize-keys w/stringify-keys)
          subreg-ext-spec*))
+
+(defn lazy-seq?
+  "Is `s` a lazy sequence?"
+  [s]
+  (instance? #?(:clj clojure.lang.LazySeq
+                :cljs cljs.core/LazySeq)
+             s))

--- a/src/main/com/yetanalytics/persephone/utils/statement.cljc
+++ b/src/main/com/yetanalytics/persephone/utils/statement.cljc
@@ -6,7 +6,11 @@
             [com.yetanalytics.pan.objects.profile :as pan-prof]
             [com.yetanalytics.persephone.utils.time :as time]))
 
-(def subreg-iri
+;; TODO: Delete in next break ver
+(def ^:deprecated subreg-iri
+  "https://w3id.org/xapi/profiles/extensions/subregistration")
+
+(def subregistration-iri
   "https://w3id.org/xapi/profiles/extensions/subregistration")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -90,7 +94,9 @@
    extension value (a coll of subreg objects), or a keyword if the
    subregistration value is invalid."
   [statement registration]
-  (let [subreg-ext (get-in statement ["context" "extensions" subreg-iri])]
+  (let [subreg-ext (get-in statement ["context"
+                                      "extensions"
+                                      subregistration-iri])]
     (when (some? subreg-ext)
       (cond
         ;; Subregistrations present without registration

--- a/src/test/com/yetanalytics/persephone_test.cljc
+++ b/src/test/com/yetanalytics/persephone_test.cljc
@@ -4,15 +4,10 @@
             [com.yetanalytics.persephone.template.statement-ref :as sref]
             [com.yetanalytics.persephone.pattern.errors :as perrs]
             [com.yetanalytics.persephone.utils.statement :as stmt]
-            [com.yetanalytics.persephone-test.test-utils :as test-u]))
-
-;; https://stackoverflow.com/questions/38880796/how-to-load-a-local-file-for-a-clojurescript-test
-
-;; TODO: Move to test-utils
-#?(:cljs
-   (defn slurp [path]
-     (let [fs (js/require "fs")]
-       (.readFileSync fs path "utf8"))))
+            #?(:clj
+               [com.yetanalytics.persephone-test.test-utils :as test-u]
+               :cljs
+               [com.yetanalytics.persephone-test.test-utils :as test-u :refer [slurp]])))
 
 (use-fixtures :once test-u/instrumentation-fixture)
 

--- a/src/test/com/yetanalytics/persephone_test.cljc
+++ b/src/test/com/yetanalytics/persephone_test.cljc
@@ -1,5 +1,5 @@
 (ns com.yetanalytics.persephone-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
             [com.yetanalytics.persephone :as p]
             [com.yetanalytics.persephone.template.statement-ref :as sref]
             [com.yetanalytics.persephone.pattern.errors :as perrs]
@@ -13,6 +13,8 @@
    (defn slurp [path]
      (let [fs (js/require "fs")]
        (.readFileSync fs path "utf8"))))
+
+(use-fixtures :once test-u/instrumentation-fixture)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Definitions + Basic test

--- a/src/test/com/yetanalytics/persephone_test.cljc
+++ b/src/test/com/yetanalytics/persephone_test.cljc
@@ -684,14 +684,14 @@ Pattern path:
 (def satisfied-stmt-3
   (-> satisfied-stmt
       (assoc-in ["context" "registration"] registration-3)
-      (assoc-in ["context" "extensions" stmt/subreg-iri]
+      (assoc-in ["context" "extensions" stmt/subregistration-iri]
                 [{"profile"         "https://w3id.org/xapi/cmi5/v1.0"
                   "subregistration" sub-reg-1}])))
 
 (def satisfied-stmt-4
   (-> satisfied-stmt
       (assoc-in ["context" "registration"] registration-3)
-      (assoc-in ["context" "extensions" stmt/subreg-iri]
+      (assoc-in ["context" "extensions" stmt/subregistration-iri]
                 [{"profile"         "https://example.org/profile"
                   "subregistration" sub-reg-3}
                  {"profile"         "https://w3id.org/xapi/cmi5/v1.0"
@@ -818,7 +818,7 @@ Pattern path:
   (testing "subregistration errors"
     (is (= ::stmt/invalid-subreg-nonconformant
            (->> (assoc-in satisfied-stmt-3
-                          ["context" "extensions" stmt/subreg-iri]
+                          ["context" "extensions" stmt/subregistration-iri]
                           [])
                 (match-cmi-2 nil)
                 :error

--- a/src/test/com/yetanalytics/persephone_test/template_test.cljc
+++ b/src/test/com/yetanalytics/persephone_test/template_test.cljc
@@ -2,16 +2,14 @@
   (:require [clojure.test :refer [deftest testing is]]
             [com.yetanalytics.persephone.template.errors :as print-errs]
             [com.yetanalytics.persephone.template :as tv]
-            [com.yetanalytics.persephone-test.test-utils :as test-u]))
+            #?(:clj
+               [com.yetanalytics.persephone-test.test-utils :as test-u]
+               :cljs
+               [com.yetanalytics.persephone-test.test-utils :as test-u :refer [slurp]])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Statement Template Tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; TODO: Move to test-utils
-#?(:cljs (defn slurp [path]
-           (let [fs (js/require "fs")]
-             (.readFileSync fs path "utf8"))))
 
 (def ex-statement-1
   (test-u/json->edn (slurp "test-resources/sample_statements/adl_1.json")))

--- a/src/test/com/yetanalytics/persephone_test/test_utils.cljc
+++ b/src/test/com/yetanalytics/persephone_test/test_utils.cljc
@@ -13,6 +13,20 @@
                              :refer [persephone-syms-var]])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Resource reading
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; https://stackoverflow.com/questions/38880796/how-to-load-a-local-file-for-a-clojurescript-test
+
+#?(:cljs
+   (defn slurp
+     "ClojureScript drop-in replacement for `clojure.core/slurp`. Only works
+      for reading local files."
+     [path]
+     (let [fs (js/require "fs")]
+       (.readFileSync fs path "utf8"))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; JSON Parsing
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Add pattern match metadata specs and implement other updates, in order to make specs easier to use with downstream apps that use persephone specs directly (e.g. Poseidon). Also finally add an instrumentation fixture.